### PR TITLE
Separate drawing and simulation

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -55,7 +55,13 @@ const game = maybeGame.get_game();
 if (!game) {
   throw new Error(`Failed to make a Game object`);
 }
-function drawOneFrame() {
+let previousFrameTime = performance.now();
+function drawOneFrame(timestamp) {
+  const elapsed = timestamp - previousFrameTime;
+  previousFrameTime = timestamp;
+  game.simulate(
+      elapsed, curInput.up, curInput.down, curInput.left, curInput.right);
+  game.draw()
   const maybeError = game.draw(
       curInput.up, curInput.down, curInput.left, curInput.right);
   if (maybeError == null) {


### PR DESCRIPTION
This gets us FPS-independent behavior (important, as FPS commonly varies a lot now!), as well as the ability to separate out simulation (which is usually fast) from drawing (which is usually slower), which can be helpful for making a game feel responsive.