### PR TITLE
Use Result<Game, JsValue> instead of GameResult

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -54,14 +54,7 @@ const drawTimes = [];
 const totalTimes = [];
 let perfIdx = 0;
 
-const maybeGame = wasm.make_game();
-if (maybeGame.get_error()) {
-  throw new Error(maybeGame.get_error());
-}
-const game = maybeGame.get_game();
-if (!game) {
-  throw new Error(`Failed to make a Game object`);
-}
+const game = wasm.make_game();
 let previousFrameTime = performance.now();
 function drawOneFrame() {
   const timestamp = performance.now();


### PR DESCRIPTION
Returning a Result<Game, JsValue> from Rust to JS means that the JS will either get a Game or it will throw the JsValue, which is the API that JS code probably expects.