### PR TITLE
Track game status

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -31,7 +31,8 @@ function drawOneFrame() {
   if (maybeError == null) {
     message = 'All is well.';
   } else {
-    message = `Failed to draw! ${maybeError}`;
+    output.innerText = `${maybeError}`;
+    return;
   }
   if (simTimes.length < 100) {
     simTimes.push(simTime);


### PR DESCRIPTION
Notice when the game is disconnected and end simulation.

This will let us add the ability to differentiate when in the lobby vs in the game for reals.