### PR TITLE
Fix the rebroadcast server

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,5 +12,6 @@ tokio-tungstenite = "0.11.0"
 tokio = { version = "0.2", default-features = false, features = ["io-std", "macros", "stream", "time"] }
 futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
 futures-channel = "0.3"
+futures = "0.3"
 url = "2.0.0"
 env_logger = "0.7"


### PR DESCRIPTION
Fixes #28

This took a long time for such a simple fix, but I learned a lot about async and futures, and a little bit about tokio!

What I should have been learning about was WebSockets. You see, there are a few different types of messages you can send with WebSockets. You can send text, you can send binary, and there's this special ping/pong format for some reason? But also one of the kinds of messages is a close message.

So, our rebroadcast server, what it does is it rebroadcasts every message received to every other client.

Including close messages.

So, that explains why when one client closes, usually all of them do. Because we rebroadcast the close message from the server to all the other clients, asking them to close the connection!

Argh!