### PR TITLE
Refine the lifecycle of a game

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -53,6 +53,14 @@ impl Position {
             .sqrt()
             .abs()
     }
+
+    fn random() -> Position {
+        let mut rng = rand::thread_rng();
+        Position {
+            x: rng.gen_range(30.0, WIDTH - 30.0),
+            y: rng.gen_range(30.0, HEIGHT - 30.0),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
@@ -158,7 +166,7 @@ pub enum ClientToServerMessage {
     Killed(DeadBody),
     FinishedTask(FinishedTask),
     Join(Player),
-    StartGame(StartGame),
+    StartGame(),
 }
 
 impl ClientToServerMessage {
@@ -169,7 +177,7 @@ impl ClientToServerMessage {
             ClientToServerMessage::Killed(_) => "Killed",
             ClientToServerMessage::FinishedTask(_) => "FinishedTask",
             ClientToServerMessage::Join(_) => "Join",
-            ClientToServerMessage::StartGame(_) => "StartGame",
+            ClientToServerMessage::StartGame() => "StartGame",
         }
     }
 }
@@ -458,14 +466,7 @@ impl GameAsPlayer {
     }
 
     fn start(&mut self) -> Result<(), String> {
-        // todo, pick this on the server
-        let impostor_index = rand::thread_rng().gen_range(0, self.game.players.len());
-        let impostor = &self.game.players[impostor_index];
-        let impostors = vec![impostor.uuid];
-        let start_data = StartGame { impostors };
-        self.game.note_game_started(&start_data)?;
-        self.socket
-            .send(&ClientToServerMessage::StartGame(start_data))?;
+        self.socket.send(&ClientToServerMessage::StartGame())?;
         Ok(())
     }
 }
@@ -523,17 +524,26 @@ impl Game {
         Ok(())
     }
 
-    fn note_game_started(&mut self, start_data: &StartGame) -> Result<(), String> {
+    fn note_game_started(&mut self) -> Result<(), String> {
         if self.status != GameStatus::Lobby {
             return Err(format!("Internal error: got a message to start a game when not in the lobby!? Game status: {:?}", self.status));
         }
+        let impostor_index = rand::thread_rng().gen_range(0, self.players.len());
+        let impostor = &self.players[impostor_index];
+        let impostors = vec![impostor.uuid];
         self.status = GameStatus::Playing;
         for player in self.players.iter_mut() {
-            for impostor_uuid in start_data.impostors.iter() {
+            for impostor_uuid in impostors.iter() {
                 if player.uuid == *impostor_uuid {
                     player.impostor = true;
                 }
             }
+            player.tasks = (0..6)
+                .map(|_| Task {
+                    finished: false,
+                    position: Position::random(),
+                })
+                .collect();
         }
         Ok(())
     }
@@ -595,7 +605,7 @@ impl Game {
 // Useful so that we can implement a real game server with web sockets, and the test
 // game server, and potentially a future peer to peer in-client server.
 pub struct GameServer {
-    game: Game,
+    pub game: Game,
     broadcaster: Box<dyn Broadcaster>,
 }
 
@@ -610,12 +620,10 @@ pub trait Broadcaster: Send {
 
 impl GameServer {
     pub fn new(broadcaster: Box<dyn Broadcaster>) -> GameServer {
-        let mut gs = GameServer {
+        GameServer {
             game: Game::new(vec![]),
             broadcaster,
-        };
-        gs.game.status = GameStatus::Lobby;
-        gs
+        }
     }
 
     pub fn simulate(&mut self, elapsed: f64) {
@@ -625,6 +633,9 @@ impl GameServer {
     pub fn disconnected(&mut self, disconnected_player: UUID) -> Result<(), Box<dyn Error>> {
         self.game.players.retain(|p| p.uuid != disconnected_player);
         self.broadcast_snapshot()?;
+        if self.game.players.is_empty() {
+            self.game.status = GameStatus::Disconnected;
+        }
         Ok(())
     }
 
@@ -635,8 +646,15 @@ impl GameServer {
     ) -> Result<(), Box<dyn Error>> {
         println!("Game server handling {:?}", message);
         match message {
-            ClientToServerMessage::StartGame(start) => {
-                self.game.note_game_started(&start)?;
+            ClientToServerMessage::StartGame() => {
+                if self.game.status != GameStatus::Lobby {
+                    print!(
+                        "Player {} tried to start a game from state {:?}",
+                        sender, self.game.status
+                    );
+                    return Ok(());
+                }
+                self.game.note_game_started()?;
                 self.broadcast_snapshot()?;
             }
             ClientToServerMessage::Killed(body) => {
@@ -753,6 +771,9 @@ mod tests {
                 .insert(uuid, vec![]);
             self.players.insert(uuid, player);
             self.player_queue.insert(uuid, queue);
+            if self.game_server.game.status == GameStatus::Connecting {
+                self.game_server.game.status = GameStatus::Lobby;
+            }
             uuid
         }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,10 +1,13 @@
 use std::error::Error;
 use std::fmt::Display;
+use std::time::Duration;
+use std::time::Instant;
 use std::{
     collections::HashMap,
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
+use tokio::time::delay_for;
 
 use futures_channel::mpsc::{unbounded, UnboundedSender};
 use futures_util::{future, pin_mut, stream::TryStreamExt, StreamExt};
@@ -72,12 +75,42 @@ impl Server {
     async fn serve(&mut self) {
         // Let's spawn the handling of each connection in a separate task.
         while let Ok((stream, addr)) = self.listener.accept().await {
+            let prev_game_finished;
+            {
+                let game_server = self.game_server.lock().unwrap();
+                prev_game_finished = game_server.game.status.finished();
+            }
+            if prev_game_finished {
+                // The previous game is finished. Create a new game and direct future players to it.
+                let room = Room::default();
+                let broadcast_server = BroadCastServer { room: room.clone() };
+                self.room = room;
+                self.game_server =
+                    Arc::new(Mutex::new(GameServer::new(Box::new(broadcast_server))));
+                println!("Starting a new game for the new client!");
+            }
             tokio::spawn(handle_connection(
                 self.game_server.clone(),
                 self.room.clone(),
                 stream,
                 addr,
             ));
+        }
+    }
+}
+
+async fn simulation_loop(game_server: Arc<Mutex<GameServer>>) {
+    let mut prev = Instant::now();
+    loop {
+        delay_for(Duration::from_millis(16)).await;
+        let now = Instant::now();
+        let elapsed = now - prev;
+        prev = now;
+        let mut game_server = game_server.lock().unwrap();
+        game_server.simulate(elapsed.as_millis() as f64);
+        if game_server.game.status.finished() {
+            println!("Game finished, done simulating it on the server.");
+            break;
         }
     }
 }
@@ -99,6 +132,14 @@ async fn handle_connection(
 
     // Insert the write part of this peer to the peer map.
     let (tx, rx) = unbounded();
+
+    {
+        let mut game_server_unlocked = game_server.lock().unwrap();
+        if game_server_unlocked.game.status == GameStatus::Connecting {
+            game_server_unlocked.game.status = GameStatus::Lobby;
+            tokio::spawn(simulation_loop(game_server.clone()));
+        }
+    }
 
     let uuid: UUID;
     println!("Waiting on initial message...");


### PR DESCRIPTION
The server is initially doing nothing. When the first player connects, we start simulating the game every 16ms until the game finishes (one side wins or every player diconnects).

When a player joins and the current game is finished, instead create a new game.

Also we now apportion out tasks and impostor status from the server, not from the player that starts the game.