### PR TITLE
Reduce jitter

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -73,7 +73,7 @@ impl Canvas {
         for body in game.game.bodies.iter() {
             self.draw_body(*body)?;
         }
-        for player in game.game.players.iter() {
+        for (_, player) in game.game.players.iter() {
             if show_dead_people || !player.dead {
                 self.draw_player(player)?
             }


### PR DESCRIPTION
Greatly reduce jitteriness of movement over a real world connection by only overwriting positions when the server sends its  game state snapshot to the client when the server's idea of a position is very different from what the client thinks it is. This way, so long as latency is low enough, movement is smooth, with no abrupt changes in position.

For perf, and to keep tests passing, also includes a change updates players to be a BTreeMap rather than a Vec. A really cool data structure that combines most of the advantages of a map and an array.