### PR TITLE
Remove the need to run the server as root

### DIFF
--- a/start_prod.sh
+++ b/start_prod.sh
@@ -12,4 +12,12 @@ echo "Building client..."
 cp -r www/dist server/dist
 gzip -9 server/dist/*
 echo "Client built, building and starting server..."
-(cd server && cargo run --bin prod --release)
+echo "Client built, building the server..."
+(cd server && cargo build --release)
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  echo "Running sudo setcap to allow prod server to bind to low ports"
+  sudo setcap CAP_NET_BIND_SERVICE=+eip server/target/release/prod
+fi
+
+(cd server && nohup target/release/prod) &

--- a/start_prod.sh
+++ b/start_prod.sh
@@ -9,6 +9,7 @@ fi
 
 echo "Building client..."
 (cd client && wasm-pack build --release && cd ../www && npm run build)
+rm -rf server/dist/
 cp -r www/dist server/dist
 gzip -9 server/dist/*
 echo "Client built, building and starting server..."


### PR DESCRIPTION
Turns out, you can run

`setcap CAP_NET_BIND_SERVICE=+eip my_binary` to give `my_binary` permission to bind to port 80. Nice!