### PR TITLE
Smoother collisions

### DIFF
--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -4,10 +4,10 @@ use rand::Rng;
 use serde::de::{self, Visitor};
 use serde::Deserializer;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::{collections::BTreeMap, iter::FromIterator};
+use std::{f64::consts::PI, fmt};
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Settings {
@@ -134,7 +134,7 @@ impl GameState {
       };
 
       for shape in self.map.static_geometry.iter() {
-        movement_vector = shape.collide(player.position, Player::radius(), movement_vector);
+        movement_vector = shape.collide(player.position, Player::radius(), movement_vector, 0.10);
       }
 
       // Advance the player
@@ -374,7 +374,13 @@ pub enum Shape {
 }
 
 impl Shape {
-  pub fn collide(&self, position: Position, radius: f64, movement_vector: Velocity) -> Velocity {
+  pub fn collide(
+    &self,
+    center: Position,
+    radius: f64,
+    movement_vector: Velocity,
+    friction: f64,
+  ) -> Velocity {
     match self {
       Shape::Circle {
         radius: self_radius,
@@ -387,7 +393,7 @@ impl Shape {
         // Quick check to see whether, given starting locations and the magnitude of the
         // movement these two could collide if the player moved directly at this shape.
         let sum_radii = radius + self_radius;
-        let dist = position.distance(self_center) - sum_radii;
+        let dist = center.distance(self_center) - sum_radii;
         if movement_vector.magnitude() < dist {
           // Too far away, early exit.
           return movement_vector;
@@ -396,7 +402,7 @@ impl Shape {
         let n: Velocity = movement_vector.normalize();
 
         // Determine if A is moving towards B. If not, they're not colliding
-        let c = self_center.sub(position);
+        let c = self_center.sub(center);
         let d = n.dot_product(&c);
         if d <= 0.0 {
           return movement_vector;
@@ -423,13 +429,34 @@ impl Shape {
           return movement_vector;
         }
 
-        let new_speed = n.times(distance);
+        let new_velocity = n.times(distance);
 
-        // still have t.sqrt energy that we're putting into this motion. need
-        // to figure out the angle between
-        let new_position = position.move_by(new_speed);
+        let new_position = center.move_by(new_velocity);
+        let vector_between_centers: Velocity = self_center.minus(&new_position);
+        let angle = n.angle_between(&vector_between_centers);
+        let angle_multiplier = angle * 2.0 / PI;
 
-        new_speed
+        let slope_of_tangent_line = -(1.0 / self_center.slope(&new_position));
+        let tangent_point: Position = vector_between_centers
+          .normalize::<Position>()
+          .times(*self_radius);
+        let second_tangent_point = Position {
+          x: tangent_point.x + 1.0,
+          y: tangent_point.y + slope_of_tangent_line,
+        };
+        let tangent_vector: Velocity = tangent_point.sub(second_tangent_point).normalize();
+        let reversed_tangent_vector: Velocity = tangent_vector.times(-1.0);
+        let tangent_vector = if tangent_vector.distance(&n) < reversed_tangent_vector.distance(&n) {
+          tangent_vector
+        } else {
+          reversed_tangent_vector
+        };
+
+        let leftover_magnitude = movement_magnitude - distance;
+        return new_velocity.add(
+          &tangent_vector
+            .times::<Velocity>(leftover_magnitude * angle_multiplier * (1.0 - friction)),
+        );
       }
     }
   }
@@ -535,35 +562,60 @@ impl<'de> Deserialize<'de> for UUID {
 }
 
 pub trait Vector2d {
+  #[must_use]
   fn x(&self) -> f64;
+  #[must_use]
   fn y(&self) -> f64;
+
+  #[must_use]
   fn make_from_point(x: f64, y: f64) -> Self;
 
+  #[must_use]
   fn distance(&self, other: &impl Vector2d) -> f64 {
     ((self.x() - other.x()).powi(2) + (self.y() - other.y()).powi(2))
       .sqrt()
       .abs()
   }
 
+  #[must_use]
   fn magnitude(&self) -> f64 {
     self.distance(&Position { x: 0.0, y: 0.0 })
   }
 
+  #[must_use]
   fn dot_product(&self, other: &impl Vector2d) -> f64 {
     (self.x() * other.x()) + (self.y() * other.y())
   }
 
+  #[must_use]
   fn normalize<Ret: Vector2d>(&self) -> Ret {
     let magnitude = self.magnitude();
     Ret::make_from_point(self.x() / magnitude, self.y() / magnitude)
   }
 
+  #[must_use]
   fn times<Ret: Vector2d>(&self, scalar: f64) -> Ret {
     Ret::make_from_point(self.x() * scalar, self.y() * scalar)
   }
 
+  #[must_use]
   fn add<Ret: Vector2d>(&self, summand: &impl Vector2d) -> Ret {
     Ret::make_from_point(self.x() + summand.x(), self.y() + summand.y())
+  }
+
+  #[must_use]
+  fn minus<Ret: Vector2d>(&self, subtrahend: &impl Vector2d) -> Ret {
+    Ret::make_from_point(self.x() - subtrahend.x(), self.y() - subtrahend.y())
+  }
+
+  #[must_use]
+  fn angle_between(&self, other: &impl Vector2d) -> f64 {
+    (self.dot_product(other) / (self.magnitude() * other.magnitude())).acos()
+  }
+
+  #[must_use]
+  fn slope(&self, other: &impl Vector2d) -> f64 {
+    (other.y() - self.y()) / (other.x() - self.x())
   }
 }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -147,8 +147,8 @@ impl GameAsPlayer {
     {
       let new_speed = self.get_speed();
       let player = self.local_player_mut().unwrap();
-      speed_changed = new_speed != player.speed;
-      player.speed = new_speed;
+      speed_changed = new_speed != player.velocity;
+      player.velocity = new_speed;
     }
 
     // This way we don't send a MoveMessage unless movement keys actually changed,
@@ -156,7 +156,7 @@ impl GameAsPlayer {
     if speed_changed {
       let player = self.local_player().unwrap();
       self.socket.send(&ClientToServerMessage::Move(MoveMessage {
-        speed: player.speed,
+        speed: player.velocity,
         position: player.position,
       }))?;
     }
@@ -291,7 +291,7 @@ impl GameAsPlayer {
     Ok(Some(voting_state))
   }
 
-  fn get_speed(&self) -> Speed {
+  fn get_speed(&self) -> Velocity {
     let mut dx = 0.0;
     let mut dy = 0.0;
     if self.inputs.up && !self.inputs.down {
@@ -304,7 +304,7 @@ impl GameAsPlayer {
     } else if self.inputs.right {
       dx = self.state.settings.speed
     }
-    Speed { dx, dy }
+    Velocity { dx, dy }
   }
 
   fn kill_player_near(&mut self, position: Position) -> Result<(), String> {
@@ -427,7 +427,7 @@ impl GameAsPlayer {
                 impostor,
                 tasks,
                 position,
-                speed,
+                velocity: speed,
               } = player;
               local_player.name = name;
               local_player.color = color;
@@ -436,7 +436,7 @@ impl GameAsPlayer {
               local_player.tasks = tasks;
               // Always trust our local speed over the server
               if player.uuid != self.my_uuid {
-                local_player.speed = speed;
+                local_player.velocity = speed;
               }
               // Avoid jitter by ignoring position updates (and instead use local reconning
               // based on speeds) unless the distance is greater than some small amount.

--- a/core/src/protocol.rs
+++ b/core/src/protocol.rs
@@ -71,7 +71,7 @@ pub fn get_version_sha() -> &'static str {
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct MoveMessage {
-  pub speed: Speed,
+  pub speed: Velocity,
   pub position: Position,
 }
 

--- a/core/src/server.rs
+++ b/core/src/server.rs
@@ -255,7 +255,7 @@ impl GameServer {
       }
       ClientToServerMessage::Move(moved) => {
         if let Some(player) = self.state.players.get_mut(&sender) {
-          player.speed = moved.speed;
+          player.velocity = moved.speed;
           player.position = moved.position;
         }
         self.broadcast_snapshot()?;


### PR DESCRIPTION
- Rename speed to velocity, velocity has a direction, speed does not.
- Colliding with a smooth surface redirects remaining motion. No more sticky collisions!